### PR TITLE
added option to keep OSS data

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Demo application showcasing Configuration with Design Automation for Inventor
  - Create initial data: from the `WebApplication` directory, run `dotnet run initialize=true`
  - Clear data: from the `WebApplication` directory, run `dotnet run clear=true`
  - Clear and then load initial data: from the `WebApplication` directory, run `dotnet run initialize=true clear=true`
+ - Clear AppBundles/Activities and initialize from existing data: from the `WebApplication` directory, run `dotnet run initialize=true clear=true oss=false`
 
 ## Debug The Web Application With VS Code
 

--- a/WebApplication/Startup.cs
+++ b/WebApplication/Startup.cs
@@ -77,16 +77,18 @@ namespace WebApplication
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, Initializer initializer, ILogger<Startup> logger, ResourceProvider resourceProvider)
         {
-            if(Configuration.GetValue<bool>("clear"))
+            bool initOSSdata = Configuration.GetValue<bool>("oss", true);
+
+            if (Configuration.GetValue<bool>("clear"))
             {
                 logger.LogInformation("-- Clean up --");
-                initializer.ClearAsync().Wait();
+                initializer.ClearAsync(initOSSdata).Wait();
             }
 
             if(Configuration.GetValue<bool>("initialize"))
             {
                 logger.LogInformation("-- Initialization --");
-                initializer.InitializeAsync().Wait();
+                initializer.InitializeAsync(initOSSdata).Wait();
             }
 
             if (env.IsDevelopment())


### PR DESCRIPTION
added option to keep OSS bucket with already uploaded data when using initialize=true clear=true to upload new updated appbundles / activities and refresh locally cached project

should be called like this:

**dotnet run initialize=true clear=true oss=false**

this is very helpful when experiencing issues with low internet upload speed