### PR TITLE
Ensure bucket existence

### DIFF
--- a/WebApplication/Controllers/ProjectsController.cs
+++ b/WebApplication/Controllers/ProjectsController.cs
@@ -38,7 +38,7 @@ namespace WebApplication.Controllers
         [HttpGet("")]
         public async Task<IEnumerable<ProjectDTO>> ListAsync()
         {
-            var bucket = await _userResolver.GetBucket(tryToCreate: false); // TODO: remove before PR
+            var bucket = await _userResolver.GetBucket(tryToCreate: true);
 
             // TODO move to projects repository?
             List<ObjectDetails> objects = await bucket.GetObjectsAsync($"{ONC.ProjectsFolder}-");


### PR DESCRIPTION
I think this was the reason why project list was not shown at prod.

"Get project list" was returning 500 error if bucket was missing, and it worked fine for dev. Seems prod tries to show custom error message instead of returning message as-is (and client-side tries to parse HTML with the message).
