### PR TITLE
Exclude local cache dir to keep VS alive

### DIFF
--- a/WebApplication/WebApplication.csproj
+++ b/WebApplication/WebApplication.csproj
@@ -22,8 +22,12 @@
 
   <ItemGroup>
     <!-- Don't publish the SPA source files, but do show them in the project files list -->
+    <Compile Remove="LocalCache\**" />
     <Content Remove="$(SpaRoot)**" />
+    <Content Remove="LocalCache\**" />
+    <EmbeddedResource Remove="LocalCache\**" />
     <None Remove="$(SpaRoot)**" />
+    <None Remove="LocalCache\**" />
     <None Include="$(SpaRoot)**" Exclude="$(SpaRoot)node_modules\**" />
   </ItemGroup>
 


### PR DESCRIPTION
After excluding `LocalCache` dir from VS project I was able to work with project with long names.