### PR TITLE
removed unnecessary file

### DIFF
--- a/AWS-CICD/.platform/nginx/conf.d/proxy.conf
+++ b/AWS-CICD/.platform/nginx/conf.d/proxy.conf
@@ -1,1 +1,0 @@
-client_max_body_size 500M;


### PR DESCRIPTION
- removed .platform file
- limit we have in CreateHostBuilder will remain here, because it modifies MaxRequestBodySize default 30000000bytes to be larger