### PR TITLE
Invgen 43717 show nominal value

### DIFF
--- a/AppBundles/ExtractParametersPlugin/ExtractParametersAutomation.cs
+++ b/AppBundles/ExtractParametersPlugin/ExtractParametersAutomation.cs
@@ -61,7 +61,7 @@ namespace ExtractParametersPlugin
                     }
 
                     // extract user parameters
-                    InventorParameters allParams = ExtractParameters(parameters);
+                    InventorParameters allParams = ExtractParameters(doc, parameters);
 
                     // save current state
                     LogTrace("Updating");
@@ -93,7 +93,7 @@ namespace ExtractParametersPlugin
                     else
                     {
                         LogTrace("No non-empty iLogic forms found. Using all user parameters.");
-                        resultingParameters = ExtractParameters(parameters.UserParameters);
+                        resultingParameters = ExtractParameters(doc, parameters.UserParameters);
                     }
 
                     // generate resulting JSON. Note it's not formatted (to have consistent hash)
@@ -110,7 +110,7 @@ namespace ExtractParametersPlugin
             }
         }
 
-        public InventorParameters ExtractParameters(dynamic userParameters)
+        public InventorParameters ExtractParameters(Document doc, dynamic userParameters)
         {
             /* The resulting json will be like this:
               { 
@@ -130,10 +130,15 @@ namespace ExtractParametersPlugin
                 var parameters = new InventorParameters();
                 foreach (dynamic param in userParameters)
                 {
+                    var unitType = doc.UnitsOfMeasure.GetTypeFromString(param.Units);
+                    var value = doc.UnitsOfMeasure.GetValueFromExpression(param.Expression, unitType);
+                    var nominalValue = doc.UnitsOfMeasure.GetPreciseStringFromValue(value, unitType);
+
                     var parameter = new InventorParameter
                     {
                         Unit = param.Units,
                         Value = param.Expression,
+                        NominalValue = nominalValue,
                         Values = param.ExpressionList?.GetExpressionList() ?? new string[0]
                     };
                     parameters.Add(param.Name, parameter);

--- a/AppBundles/ExtractParametersPlugin/ExtractParametersAutomation.cs
+++ b/AppBundles/ExtractParametersPlugin/ExtractParametersAutomation.cs
@@ -130,15 +130,23 @@ namespace ExtractParametersPlugin
                 var parameters = new InventorParameters();
                 foreach (dynamic param in userParameters)
                 {
-                    var unitType = doc.UnitsOfMeasure.GetTypeFromString(param.Units);
-                    var value = doc.UnitsOfMeasure.GetValueFromExpression(param.Expression, unitType);
-                    var nominalValue = doc.UnitsOfMeasure.GetPreciseStringFromValue(value, unitType);
+                    var nominalValue = param.Expression;
+                    try
+                    {
+                        var unitType = doc.UnitsOfMeasure.GetTypeFromString(param.Units);
+                        var value = doc.UnitsOfMeasure.GetValueFromExpression(param.Expression, unitType);
+                        nominalValue = doc.UnitsOfMeasure.GetPreciseStringFromValue(value, unitType);
+                    }
+                    // not all unitTypes seem to be convertible (e.g. kTextUnits). In that case, we'll go on with param.Value assigned before.
+                    catch (Exception e)
+                    { 
+                        LogError("Can't get nominalValue for " + param.Name + ": " + e.Message);
+                    }
 
                     var parameter = new InventorParameter
                     {
                         Unit = param.Units,
-                        Value = param.Expression,
-                        NominalValue = nominalValue,
+                        Value = nominalValue,
                         Values = param.ExpressionList?.GetExpressionList() ?? new string[0]
                     };
                     parameters.Add(param.Name, parameter);

--- a/AppBundles/ExtractParametersPlugin/ExtractParametersAutomation.cs
+++ b/AppBundles/ExtractParametersPlugin/ExtractParametersAutomation.cs
@@ -137,7 +137,7 @@ namespace ExtractParametersPlugin
                         var value = doc.UnitsOfMeasure.GetValueFromExpression(param.Expression, unitType);
                         nominalValue = doc.UnitsOfMeasure.GetPreciseStringFromValue(value, unitType);
                     }
-                    // not all unitTypes seem to be convertible (e.g. kTextUnits). In that case, we'll go on with param.Value assigned before.
+                    // not all unitTypes seem to be convertible (e.g. kTextUnits). In that case, we'll go on with param.Expression assigned before.
                     catch (Exception e)
                     { 
                         LogError("Can't get nominalValue for " + param.Name + ": " + e.Message);

--- a/AppBundles/ExtractParametersPlugin/Properties/AssemblyInfo.cs
+++ b/AppBundles/ExtractParametersPlugin/Properties/AssemblyInfo.cs
@@ -6,5 +6,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("f1c9d7e2-53a8-4e4e-af9e-931ca891715d")]
 
-[assembly: AssemblyVersion("2.0.0.12")]
-[assembly: AssemblyFileVersion("2.0.0.12")]
+[assembly: AssemblyVersion("2.0.0.13")]
+[assembly: AssemblyFileVersion("2.0.0.13")]

--- a/Shared/InventorParameters.cs
+++ b/Shared/InventorParameters.cs
@@ -36,6 +36,9 @@ namespace Shared
         [JsonProperty("value")]
         public string Value { get; set; }
 
+        [JsonProperty("nominalvalue")]
+        public string NominalValue { get; set; }
+
         [JsonProperty("unit")]
         public string Unit { get; set; }
 

--- a/Shared/InventorParameters.cs
+++ b/Shared/InventorParameters.cs
@@ -36,9 +36,6 @@ namespace Shared
         [JsonProperty("value")]
         public string Value { get; set; }
 
-        [JsonProperty("nominalvalue")]
-        public string NominalValue { get; set; }
-
         [JsonProperty("unit")]
         public string Unit { get; set; }
 


### PR DESCRIPTION
A change to use nominalValue instead of Expression, for calculated parameters. 
Will not work if the expression is not valid (e.g. when units of expression do not match the desired unit of the parameter).