### PR TITLE
Return BOM url in unified way for both adopt and update

### DIFF
--- a/AppBundles/ExportBOMPlugin/Properties/AssemblyInfo.cs
+++ b/AppBundles/ExportBOMPlugin/Properties/AssemblyInfo.cs
@@ -6,5 +6,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("f1c9d7e2-53a8-4e4e-af9e-931ca891715d")]
 
-[assembly: AssemblyVersion("1.0.0.2")]
-[assembly: AssemblyFileVersion("1.0.0.2")]
+[assembly: AssemblyVersion("1.0.0.3")]
+[assembly: AssemblyFileVersion("1.0.0.3")]

--- a/WebApplication/Definitions/ProjectDTOBase.cs
+++ b/WebApplication/Definitions/ProjectDTOBase.cs
@@ -29,6 +29,11 @@ namespace WebApplication.Definitions
         public string Svf { get; set; }
 
         /// <summary>
+        /// URL to BOM JSON.
+        /// </summary>
+        public string BomJsonUrl { get; set; }
+
+        /// <summary>
         /// URL to download current model
         /// </summary>
         public string ModelDownloadUrl { get; set; }

--- a/WebApplication/Utilities/DtoGenerator.cs
+++ b/WebApplication/Utilities/DtoGenerator.cs
@@ -47,12 +47,14 @@ namespace WebApplication.Utilities
                                                                     action: "Model",
                                                                     values: new { projectName = project.Name, hash });
 
+            var localNames = project.LocalNameProvider(hash);
             return new TProjectDTOBase
                     {
-                        Svf = _localCache.ToDataUrl(project.LocalNameProvider(hash).SvfDir),
+                        Svf = _localCache.ToDataUrl(localNames.SvfDir),
+                        BomJsonUrl = _localCache.ToDataUrl(localNames.BOM),
                         ModelDownloadUrl = modelDownloadUrl,
                         Hash = hash
-            };
+                    };
         }
 
         /// <summary>


### PR DESCRIPTION
Now "list projects" and "update parameter" returns DTO with `BomJsonUrl` field. Like:
```json
{
  "bomJsonUrl": "/data/_anonymous/Wrench/60DC1E1241D3DFC25CF9E9CA0911A662EFFFD1EE/bom.json",
  "hash": "60DC1E1241D3DFC25CF9E9CA0911A662EFFFD1EE",
  "id": "Wrench",
  "image": "/data/_anonymous/Wrench/thumbnail.png",
  "label": "Wrench",
  "modelDownloadUrl": "/download/Wrench/60DC1E1241D3DFC25CF9E9CA0911A662EFFFD1EE/model",
  "svf": "/data/_anonymous/Wrench/60DC1E1241D3DFC25CF9E9CA0911A662EFFFD1EE/SVF"
}
```