### PR TITLE
Less logging

### DIFF
--- a/WebApplication/Program.cs
+++ b/WebApplication/Program.cs
@@ -17,6 +17,7 @@
 /////////////////////////////////////////////////////////////////////
 
 using System;
+using System.IO;
 using Autodesk.Forge.Core;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -34,18 +35,21 @@ namespace WebApplication
 
         public static IHostBuilder CreateHostBuilder(string[] args)
         {
-            Log.Logger = new LoggerConfiguration()
-                .WriteTo.File("console.log")
-                .WriteTo.Console()
-                .CreateLogger();
-
-            return Host.CreateDefaultBuilder(args)
-                .UseSerilog()
-                .ConfigureAppConfiguration(builder =>
+            return Host
+                .CreateDefaultBuilder(args)
+                .ConfigureAppConfiguration(configBuilder =>
                 {
-                    builder
-                        .AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: true)
+                    configBuilder
+                        .AddJsonFile("appsettings.Local.json", optional: true, reloadOnChange: false)
                         .AddForgeAlternativeEnvironmentVariables();
+                })
+                .UseSerilog((context, logConfig) =>
+                {
+                    logConfig
+                        .ReadFrom.Configuration(context.Configuration)
+                        .Enrich.FromLogContext()
+                        .WriteTo.File("console.log")
+                        .WriteTo.Console();
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/WebApplication/Startup.cs
+++ b/WebApplication/Startup.cs
@@ -27,6 +27,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Serilog;
 using WebApplication.Definitions;
 using WebApplication.Middleware;
 using WebApplication.Processing;
@@ -153,6 +154,8 @@ namespace WebApplication
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }
+
+            app.UseSerilogRequestLogging();
 
             app.UseHttpsRedirection();
             app.UseStaticFiles();

--- a/WebApplication/appsettings.Development.json
+++ b/WebApplication/appsettings.Development.json
@@ -1,11 +1,4 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  },
   "Processing": {
     "SaveReport": "All"
   }

--- a/WebApplication/appsettings.json
+++ b/WebApplication/appsettings.json
@@ -38,8 +38,8 @@
     "MinimumLevel": {
       "Default": "Information",
       "Override": {
-        "Microsoft": "Warning",
         "System": "Warning",
+        "Microsoft.AspNetCore": "Warning",
         "Microsoft.Hosting.Lifetime": "Information"
       }
     }

--- a/WebApplication/appsettings.json
+++ b/WebApplication/appsettings.json
@@ -1,11 +1,4 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
-    }
-  },
   "AllowedHosts": "*",
   "AppBundleZipPaths": {
     "EmptyExe": "AppBundles/EmptyExePlugin.bundle.zip",
@@ -40,5 +33,15 @@
   },
   "Processing": {
     "SaveReport": "ErrorsOnly"
+  },
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning",
+        "Microsoft.Hosting.Lifetime": "Information"
+      }
+    }
   }
 }


### PR DESCRIPTION
Right now logging is polluted with ASP.NET info and it's hard to read the logs, so it's an attempt to shrink them.
With this PR the HTTP requests get logged with [Serilog middleware](https://github.com/serilog/serilog-aspnetcore#request-logging):
```
[18:35:06 INF] Get profile
[18:35:06 INF] HTTP GET /login/profile responded 200 in 135.7459 ms
```
instead of
```
2020-07-06 13:34:35.702 +03:00 [INF] Executing endpoint 'WebApplication.Controllers.LoginController.Profile (WebApplication)'
2020-07-06 13:34:35.724 +03:00 [INF] Route matched with {action = "Profile", controller = "Login"}. Executing controller action with signature System.Threading.Tasks.Task`1[WebApplication.Definitions.ProfileDTO] Profile() on controller WebApplication.Controllers.LoginController (WebApplication).
2020-07-06 13:34:35.764 +03:00 [INF] Get profile
2020-07-06 13:34:36.475 +03:00 [INF] Executing ObjectResult, writing value of type 'WebApplication.Definitions.ProfileDTO'.
2020-07-06 13:34:36.480 +03:00 [INF] Executed action WebApplication.Controllers.LoginController.Profile (WebApplication) in 718.0611ms
2020-07-06 13:34:36.483 +03:00 [INF] Executed endpoint 'WebApplication.Controllers.LoginController.Profile (WebApplication)'
2020-07-06 13:34:36.486 +03:00 [INF] Request finished in 787.2247ms 200 application/json; charset=utf-8
```