### PR TITLE
INVGEN-45246 activate project before BOM extraction

### DIFF
--- a/AppBundles/ExportBOMPlugin/Properties/AssemblyInfo.cs
+++ b/AppBundles/ExportBOMPlugin/Properties/AssemblyInfo.cs
@@ -6,5 +6,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("f1c9d7e2-53a8-4e4e-af9e-931ca891715d")]
 
-[assembly: AssemblyVersion("1.0.0.3")]
-[assembly: AssemblyFileVersion("1.0.0.3")]
+[assembly: AssemblyVersion("1.0.0.4")]
+[assembly: AssemblyFileVersion("1.0.0.4")]


### PR DESCRIPTION
added activate of default project before BOM extraction, because otherwise doc has still some unresolved drawing updates and throw exception and bom is not working (temporary solution until not deployes new inventorcoreconsole.exe to PROD environment)